### PR TITLE
fix cyclus_deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,13 @@ build:
 
 requirements:
   build:
+    - {{ compiler('cxx') }}
     - python
   run:
+    - glibmm=2.48
+    - glib==2.48 
+    - libxml2 
+    - libxmlpp
     - python
     - make
     - cmake
@@ -38,7 +43,6 @@ requirements:
     - pandas
     - jinja2
     - cython
-    - gcc
     - websockets  # [py3k]
     - pprintpp
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win or py27 or py34 or (osx and py35)]
   features:
     - blas_{{ variant }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,8 @@ requirements:
     - {{ compiler('cxx') }}
     - python
   run:
-    - glibmm=2.48
-    - glib==2.48 
+    - glibmm 2.48
+    - glib 2.48 
     - libxml2 
     - libxmlpp
     - python


### PR DESCRIPTION
cyclus-deps and cyclus conda recipe are broken.

this is an attempt to fix it.
I am not sure I do the right thing but I have been able to compile cyclus using those package:
```
python make cmake pkg-config coincbc openblas lapack boost=1.66.0 hdf5 sqlite pcre gettext bzip2 xz setuptools nose pytables pandas jinja2 cython websockets pprintpp glibmm=2.48 glib==2.48 libxml2 libxmlpp
```
on a debian container reliying on system (not conda) `gcc4.9` and `g++4.9`

I am not sure I am doing the right thing here, 
I could definitely use help there (I have no idea what I doing, or how to do it correctly...)  @scopatz @FlanFlanagan @gonuke
Also how to test recipes before merging the branch...