### PR TITLE
Add Katy & Robert to list of maintainers in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,6 @@ Feedstock Maintainers
 * [@bam241](https://github.com/bam241/)
 * [@gonuke](https://github.com/gonuke/)
 * [@scopatz](https://github.com/scopatz/)
+* [@katyhuff](https://github.com/katyhuff/)
+* [@FlanFlanagan](https://github.com/FlanFlanagan/)
 


### PR DESCRIPTION
Apologies for accidentally pushing to master with small changes on the website!  I'll refrain from that....

This change will add @katyhuff and @FlanFlanagan to the Readme