### PR TITLE
Add katy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,4 @@ Feedstock Maintainers
 * [@bam241](https://github.com/bam241/)
 * [@gonuke](https://github.com/gonuke/)
 * [@scopatz](https://github.com/scopatz/)
-
+* [@katyhuff](https://github.com/katyhuff/)


### PR DESCRIPTION
Maybe this is supposed to be handled by the linter.. but I seem to be missing still, from the list in the readme. This PR just adds my name to the readme. 

Checklist
* [x] Used a fork of the feedstock to propose changes